### PR TITLE
Bugfix: Check if content-type exists in headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ SwaggerMocha.prototype.getResults = function(callback) {
         return next(new Error('Could not find ' + data.requestUrl + '. Reason: ' + err.message));
       }
 
-      if (res.headers['content-type'].includes('text/')) {
+      if (res.headers['content-type'] && res.headers['content-type'].includes('text/')) {
         data.result = res.text;
       } else {
         data.result = res.body;


### PR DESCRIPTION
I introduced this bug 4 years ago and today I need to fix it because of the pusher tests. 